### PR TITLE
updates for new domain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,8 +3,8 @@ import partytown from '@astrojs/partytown';
 import pagefind from "astro-pagefind";
 
 export default defineConfig({
-    site: 'https://tammyzhang-1.github.io',
-    base: '/cisl-visualization-gallery',
+    site: 'https://visualizations.ucar.edu',
+    base: '/',
     integrations: [ partytown({
         config: {
           forward: ["dataLayer.push"],

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -12,10 +12,10 @@ tags.forEach((tag) => {
 })
 if (!images[coverImage]) throw new Error(`"${coverImage}" does not exist in glob: "src/assets/*.{jpeg,jpg,png,gif}"`);
 ---
-<a class="card-container" href={"/cisl-visualization-gallery/visualizations/" + slug} data-tags={tagClasses}>
+<a class="card-container" href={"/visualizations/" + slug} data-tags={tagClasses}>
   <div class="card hoverable">
     <div class="card-tag">
-      <img src={"/cisl-visualization-gallery/icons/" + mediaType.replaceAll(" ", "-").toLowerCase() + "-tag.svg"} alt={"This visualization is of type " + mediaType}/>
+      <img src={"/icons/" + mediaType.replaceAll(" ", "-").toLowerCase() + "-tag.svg"} alt={"This visualization is of type " + mediaType}/>
       <p>{mediaType.replace(/\w\S*/g, text => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase())}</p>
     </div>
     <Image class="card-image" src={images[coverImage]()} alt={title} />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,7 +11,7 @@ import nsfLogo from '/src/assets/nsf-logo.png';
             </div>
             <div id="footer-links">
                 <div class="footer-column">
-                    <a href="/cisl-visualization-gallery/about">About Us</a>
+                    <a href="/about">About Us</a>
                     <a target="_blank" href="https://ncar.ucar.edu/">NCAR</a>
                     <a target="_blank" href="https://www.ucar.edu/">UCAR</a>
                     <a target="_blank" href="https://www.cisl.ucar.edu/">CISL</a>
@@ -31,7 +31,7 @@ import nsfLogo from '/src/assets/nsf-logo.png';
             <span>
                 <a id="footer-youtube" target="_blank" href="https://www.youtube.com/@NSFNCARVisLab">
                     <span class="underline">Subscribe to us on YouTube</span> 
-                    <img src="/cisl-visualization-gallery/icons/youtube.svg" alt="link to youtube channel" />
+                    <img src="/icons/youtube.svg" alt="link to youtube channel" />
                 </a>
             </span>
         </div>
@@ -191,10 +191,10 @@ import nsfLogo from '/src/assets/nsf-logo.png';
     const youtubeLink = document.querySelector<HTMLElement>('#footer-youtube');
 
     youtubeLink.addEventListener("mouseover", (event) => { 
-        youtubeLink.getElementsByTagName('img')[0].src = "/cisl-visualization-gallery/icons/youtube-hover.svg";
+        youtubeLink.getElementsByTagName('img')[0].src = "/icons/youtube-hover.svg";
     });
 
     youtubeLink.addEventListener("mouseout", (event) => { 
-        youtubeLink.getElementsByTagName('img')[0].src = "/cisl-visualization-gallery/icons/youtube.svg";
+        youtubeLink.getElementsByTagName('img')[0].src = "/icons/youtube.svg";
     });
 </script>

--- a/src/components/GalleryFilters.astro
+++ b/src/components/GalleryFilters.astro
@@ -408,7 +408,7 @@
   generateGallery();
 
   document.addEventListener('astro:after-swap', () => {
-    if (window.location.pathname == '/cisl-visualization-gallery' || window.location.pathname == '/cisl-visualization-gallery/'){
+    if (window.location.pathname == '/'){
       generateGallery();
     }
   });

--- a/src/components/Heading.astro
+++ b/src/components/Heading.astro
@@ -11,7 +11,7 @@ import SearchField from './SearchField.astro';
       <Image id="logo" class="hoverable" src={logo} alt="NSF NCAR logo" />
     </a>
     <h1 id="title-text" class="hoverable">
-      <a href="/cisl-visualization-gallery">
+      <a href="/">
         <span id="full-title">Visualization Services and Research</span>
         <span id="abbrev-title">ViSR</span>
       </a>
@@ -19,7 +19,7 @@ import SearchField from './SearchField.astro';
   </div>
   <div id="navigation">
     <li id="about">
-      <a href="/cisl-visualization-gallery/about">
+      <a href="/about">
         About
       </a>
     </li>

--- a/src/components/SearchField.astro
+++ b/src/components/SearchField.astro
@@ -1,5 +1,5 @@
-<link href="/cisl-visualization-gallery/pagefind/pagefind-ui.css" rel="stylesheet">
-<script is:inline src="/cisl-visualization-gallery/pagefind/pagefind-ui.js"></script>
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+<script is:inline src="/pagefind/pagefind-ui.js"></script>
 
 <div id="search"></div>
 
@@ -142,8 +142,8 @@
             element: "#search", 
             showSubResults: false,
             showImages: true,
-            bundlePath: "/cisl-visualization-gallery/pagefind/", 
-            baseUrl: "/cisl-visualization-gallery/"
+            bundlePath: "/pagefind/", 
+            baseUrl: "/"
         });
     });
 
@@ -152,8 +152,8 @@
             element: "#search", 
             showSubResults: false,
             showImages: true,
-            bundlePath: "/cisl-visualization-gallery/pagefind/",
-            baseUrl: "/cisl-visualization-gallery/"
+            bundlePath: "/pagefind/",
+            baseUrl: "/"
         });
     });
 </script>

--- a/src/components/Slide.astro
+++ b/src/components/Slide.astro
@@ -9,7 +9,7 @@ const {heroImage, label, title, subtitle, slug} = Astro.props;
     <h3 class="slide-label">{label}</h3>
     <h2 class="slide-title">{title}</h2>
     <h3 class="slide-subtitle">{subtitle}</h3>
-    <a class="slide-link" href={"/cisl-visualization-gallery/visualizations/" + slug }>See More →</a>
+    <a class="slide-link" href={"/visualizations/" + slug }>See More →</a>
 </div>
 <div class="slide-background">
     <div class="slide-overlay"></div>

--- a/src/components/Slideshow.astro
+++ b/src/components/Slideshow.astro
@@ -180,7 +180,7 @@ import Slide from './Slide.astro';
     generateSlideshow();
 
     document.addEventListener('astro:after-swap', () => {
-        if (window.location.pathname == '/cisl-visualization-gallery' || window.location.pathname == '/cisl-visualization-gallery/'){
+        if (window.location.pathname == '/'){
             generateSlideshow();
         }
     });

--- a/src/components/WhatWeDo.astro
+++ b/src/components/WhatWeDo.astro
@@ -13,33 +13,33 @@ import WhatWeDoCard from "./WhatWeDoCard.astro";
         of mediums to promote the understanding of our planet's atmosphere and
         it's complicated relationships with the rest of the Earth system,
         including the oceans, the land surface, and the Sun.
-        <a id="about-us-link" href="/cisl-visualization-gallery/about"
+        <a id="about-us-link" href="/about"
             ><span class="underline"> More about us</span> →</a
         >
     </p>
     <div id="thumbnail-container">
         <WhatWeDoCard
-            icon={"/cisl-visualization-gallery/icons/videos.svg"}
+            icon={"/icons/videos.svg"}
             label={"Videos"}
             id="videos"
         />
         <WhatWeDoCard
-            icon={"/cisl-visualization-gallery/icons/web-visualizations.svg"}
+            icon={"/icons/web-visualizations.svg"}
             label={"Web Interactives"}
             id="web-visualizations"
         />
         <WhatWeDoCard
-            icon={"/cisl-visualization-gallery/icons/exhibits.svg"}
+            icon={"/icons/exhibits.svg"}
             label={"Exhibits"}
             id="exhibits"
         />
         <WhatWeDoCard
-            icon={"/cisl-visualization-gallery/icons/infographics.svg"}
+            icon={"/icons/infographics.svg"}
             label={"Infographics"}
             id="infographics"
         />
         <WhatWeDoCard
-            icon={"/cisl-visualization-gallery/icons/mobile-apps.svg"}
+            icon={"/icons/mobile-apps.svg"}
             label={"Mobile Apps"}
             id="mobile-apps"
         />

--- a/src/components/WhatWeDoCard.astro
+++ b/src/components/WhatWeDoCard.astro
@@ -80,12 +80,12 @@ const { icon, label, id } = Astro.props;
         mediaThumbnails.forEach((thumbnail) => {
             thumbnail.addEventListener("mouseover", (event) => {
                 thumbnail.classList.toggle("hovered-thumbnail");
-                thumbnail.getElementsByTagName('img')[0].src = "/cisl-visualization-gallery/icons/" + thumbnail.id + "-hover.svg";
+                thumbnail.getElementsByTagName('img')[0].src = "/icons/" + thumbnail.id + "-hover.svg";
             })
 
             thumbnail.addEventListener("mouseout", (event) => {
                 thumbnail.classList.toggle("hovered-thumbnail");
-                thumbnail.getElementsByTagName('img')[0].src = "/cisl-visualization-gallery/icons/" + thumbnail.id + ".svg";
+                thumbnail.getElementsByTagName('img')[0].src = "/icons/" + thumbnail.id + ".svg";
             })
         })
     }

--- a/src/content/visualizations/augmented-reality.md
+++ b/src/content/visualizations/augmented-reality.md
@@ -35,7 +35,7 @@ mediaType: "App"
 
 <br />
 
-NSF NCAR has implemented Augmented and [Virtual Reality](/cisl-visualization-gallery/visualizations/virtual-reality) (AR/VR) technologies to help make NCAR science more engaging and accessible to a wider audience. We have developed mobile apps and tools that enable users to explore geoscience data from their mobile device, such as an iPhone, iPad, or an Android device.   The apps are free and available for download at the Apple Store and for Android devices at Google Play.
+NSF NCAR has implemented Augmented and [Virtual Reality](/visualizations/virtual-reality) (AR/VR) technologies to help make NCAR science more engaging and accessible to a wider audience. We have developed mobile apps and tools that enable users to explore geoscience data from their mobile device, such as an iPhone, iPad, or an Android device.   The apps are free and available for download at the Apple Store and for Android devices at Google Play.
 
 #### Meteo AR
 

--- a/src/content/visualizations/virtual-reality.md
+++ b/src/content/visualizations/virtual-reality.md
@@ -34,7 +34,7 @@ mediaType: "App"
 ---
 <br />
 
-NSF NCAR has implemented Virtual and [Augmented Reality](/cisl-visualization-gallery/visualizations/augmented-reality) (AR/VR) technologies to help make NCAR science more engaging and accessible to a wider audience. We have developed mobile apps and tools that enable users to explore geoscience data from their mobile device, such as an iPhone, iPad, or an Android device.   The apps are free and available for download at the Apple Store and for Android devices at Google Play.
+NSF NCAR has implemented Virtual and [Augmented Reality](/visualizations/augmented-reality) (AR/VR) technologies to help make NCAR science more engaging and accessible to a wider audience. We have developed mobile apps and tools that enable users to explore geoscience data from their mobile device, such as an iPhone, iPad, or an Android device.   The apps are free and available for download at the Apple Store and for Android devices at Google Play.
 
 ___
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,7 +10,7 @@ import Footer from "../components/Footer.astro";
 		<link
 			rel="icon"
 			type="image/svg+xml"
-			href="/cisl-visualization-gallery/favicon.ico"
+			href="/favicon.ico"
 		/>
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ const allPosts = await getCollection('visualizations');
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/cisl-visualization-gallery/favicon.ico" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<title>NSF NCAR | Visualization Gallery</title>

--- a/src/pages/visualizations/[...slug].astro
+++ b/src/pages/visualizations/[...slug].astro
@@ -20,7 +20,7 @@ const { Content } = await entry.render();
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/cisl-visualization-gallery/favicon.ico" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<title>NSF NCAR | Visualization Gallery</title>


### PR DESCRIPTION
on the new domain, it uses the complete domain so `/cisl-visualization-gallery` is not needed in URLs or asset including.